### PR TITLE
Mechanism to block reads and writes to a database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,11 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3471,6 +3475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,6 +3648,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "axum",
  "base64 0.21.1",
  "bincode",
  "bottomless",

--- a/sqld/Cargo.toml
+++ b/sqld/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "sqld"
 anyhow = "1.0.66"
 async-lock = "2.6.0"
 async-trait = "0.1.58"
+axum = "0.6.18"
 base64 = "0.21.0"
 bincode = "1.3.3"
 bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"], optional = true }

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::database::config::{BlockLevel, DatabaseConfig, DatabaseConfigStore};
+use crate::database::config::{DatabaseConfig, DatabaseConfigStore};
 
 struct AppState {
     db_config_store: Arc<DatabaseConfigStore>,
@@ -43,7 +43,8 @@ async fn handle_get_config(State(app_state): State<Arc<AppState>>) -> Json<Arc<D
 
 #[derive(Debug, Deserialize)]
 struct BlockReq {
-    block_level: BlockLevel,
+    block_reads: bool,
+    block_writes: bool,
     #[serde(default)]
     block_reason: Option<String>,
 }
@@ -53,7 +54,8 @@ async fn handle_post_block(
     Json(req): Json<BlockReq>,
 ) -> (axum::http::StatusCode, &'static str) {
     let mut config = (*app_state.db_config_store.get()).clone();
-    config.block_level = req.block_level;
+    config.block_reads = req.block_reads;
+    config.block_writes = req.block_writes;
     config.block_reason = req.block_reason;
 
     match app_state.db_config_store.store(config) {

--- a/sqld/src/admin_api.rs
+++ b/sqld/src/admin_api.rs
@@ -1,0 +1,75 @@
+use anyhow::Context as _;
+use axum::Json;
+use enclose::enclose;
+use serde::Deserialize;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use crate::database::config::{BlockLevel, DatabaseConfig, DatabaseConfigStore};
+
+pub async fn run_admin_api(
+    addr: SocketAddr,
+    db_config_store: Arc<DatabaseConfigStore>,
+) -> anyhow::Result<()> {
+    use axum::routing::{get, post};
+    let router = axum::Router::new()
+        .route("/", get(handle_get_index))
+        .route(
+            "/v1/config",
+            get(enclose! {(db_config_store) move || async move {
+                handle_get_config(&db_config_store).await
+            }}),
+        )
+        .route(
+            "/v1/block",
+            post(enclose! {(db_config_store) move |req| async move{
+                handle_post_block(&db_config_store, req).await
+            }}),
+        );
+
+    let server = hyper::Server::try_bind(&addr)
+        .context("Could not bind admin HTTP API server")?
+        .serve(router.into_make_service());
+
+    tracing::info!(
+        "Listening for admin HTTP API requests on {}",
+        server.local_addr()
+    );
+    server.await?;
+    Ok(())
+}
+
+async fn handle_get_index() -> String {
+    "Welcome to the sqld admin API".into()
+}
+
+async fn handle_get_config(db_config_store: &DatabaseConfigStore) -> Json<Arc<DatabaseConfig>> {
+    Json(db_config_store.get())
+}
+
+#[derive(Debug, Deserialize)]
+struct BlockReq {
+    block_level: BlockLevel,
+    #[serde(default)]
+    block_reason: Option<String>,
+}
+
+async fn handle_post_block(
+    db_config_store: &DatabaseConfigStore,
+    Json(req): Json<BlockReq>,
+) -> (axum::http::StatusCode, String) {
+    let mut config = (*db_config_store.get()).clone();
+    config.block_level = req.block_level;
+    config.block_reason = req.block_reason;
+
+    match db_config_store.store(config) {
+        Ok(()) => (axum::http::StatusCode::OK, "OK".into()),
+        Err(err) => {
+            tracing::warn!("Could not store database config: {err}");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed".into(),
+            )
+        }
+    }
+}

--- a/sqld/src/database/config.rs
+++ b/sqld/src/database/config.rs
@@ -13,7 +13,7 @@ pub struct DatabaseConfigStore {
     config: Mutex<Arc<DatabaseConfig>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct DatabaseConfig {
     #[serde(default)]
     pub block_level: BlockLevel,
@@ -57,7 +57,11 @@ impl DatabaseConfigStore {
         }
     }
 
-    pub fn set(&self, config: DatabaseConfig) -> Result<()> {
+    pub fn get(&self) -> Arc<DatabaseConfig> {
+        self.config.lock().clone()
+    }
+
+    pub fn store(&self, config: DatabaseConfig) -> Result<()> {
         let data = serde_json::to_vec_pretty(&config)?;
         fs::write(&self.tmp_config_path, data)?;
         fs::rename(&self.tmp_config_path, &self.config_path)?;

--- a/sqld/src/database/config.rs
+++ b/sqld/src/database/config.rs
@@ -33,6 +33,8 @@ pub enum BlockLevel {
     BlockWrites,
     /// Block both read and write SQL statements.
     BlockReads,
+    /// Block all SQL statements.
+    BlockEverything,
 }
 
 impl DatabaseConfigStore {

--- a/sqld/src/database/config.rs
+++ b/sqld/src/database/config.rs
@@ -16,25 +16,12 @@ pub struct DatabaseConfigStore {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct DatabaseConfig {
     #[serde(default)]
-    pub block_level: BlockLevel,
+    pub block_reads: bool,
+    #[serde(default)]
+    pub block_writes: bool,
     /// The reason why operations are blocked. This will be included in [`Error::Blocked`].
     #[serde(default)]
     pub block_reason: Option<String>,
-}
-
-/// Determines which operations to block.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum BlockLevel {
-    /// Don't block any operations.
-    #[default]
-    BlockNothing,
-    /// Block write SQL statements.
-    BlockWrites,
-    /// Block both read and write SQL statements.
-    BlockReads,
-    /// Block all SQL statements.
-    BlockEverything,
 }
 
 impl DatabaseConfigStore {
@@ -73,14 +60,6 @@ impl DatabaseConfigStore {
         fs::write(&self.tmp_config_path, data)?;
         fs::rename(&self.tmp_config_path, &self.config_path)?;
         *self.config.lock() = Arc::new(config);
-        Ok(())
-    }
-
-    pub fn check_block_level(&self, max_block_level: BlockLevel) -> Result<()> {
-        let config = self.config.lock();
-        if config.block_level >= max_block_level {
-            return Err(Error::Blocked(config.block_reason.clone()));
-        }
         Ok(())
     }
 }

--- a/sqld/src/database/config.rs
+++ b/sqld/src/database/config.rs
@@ -17,16 +17,21 @@ pub struct DatabaseConfigStore {
 pub struct DatabaseConfig {
     #[serde(default)]
     pub block_level: BlockLevel,
+    /// The reason why operations are blocked. This will be included in [`Error::Blocked`].
     #[serde(default)]
     pub block_reason: Option<String>,
 }
 
+/// Determines which operations to block.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockLevel {
+    /// Don't block any operations.
     #[default]
     BlockNothing,
+    /// Block write SQL statements.
     BlockWrites,
+    /// Block both read and write SQL statements.
     BlockReads,
 }
 

--- a/sqld/src/database/config.rs
+++ b/sqld/src/database/config.rs
@@ -1,0 +1,75 @@
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{fs, io};
+
+use crate::error::Error;
+use crate::Result;
+
+pub struct DatabaseConfigStore {
+    config_path: PathBuf,
+    tmp_config_path: PathBuf,
+    config: Mutex<Arc<DatabaseConfig>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct DatabaseConfig {
+    #[serde(default)]
+    pub block_level: BlockLevel,
+    #[serde(default)]
+    pub block_reason: Option<String>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockLevel {
+    #[default]
+    BlockNothing,
+    BlockWrites,
+    BlockReads,
+}
+
+impl DatabaseConfigStore {
+    pub fn load(db_path: &Path) -> Result<Self> {
+        let config_path = db_path.join("config.json");
+        let tmp_config_path = db_path.join("config.json~");
+
+        let config = match fs::read(&config_path) {
+            Ok(data) => serde_json::from_slice(&data)?,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => DatabaseConfig::default(),
+            Err(err) => return Err(Error::IOError(err)),
+        };
+
+        Ok(Self {
+            config_path,
+            tmp_config_path,
+            config: Mutex::new(Arc::new(config)),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_test() -> Self {
+        Self {
+            config_path: "".into(),
+            tmp_config_path: "".into(),
+            config: Mutex::new(Arc::new(DatabaseConfig::default())),
+        }
+    }
+
+    pub fn set(&self, config: DatabaseConfig) -> Result<()> {
+        let data = serde_json::to_vec_pretty(&config)?;
+        fs::write(&self.tmp_config_path, data)?;
+        fs::rename(&self.tmp_config_path, &self.config_path)?;
+        *self.config.lock() = Arc::new(config);
+        Ok(())
+    }
+
+    pub fn check_block_level(&self, max_block_level: BlockLevel) -> Result<()> {
+        let config = self.config.lock();
+        if config.block_level >= max_block_level {
+            return Err(Error::Blocked(config.block_reason.clone()));
+        }
+        Ok(())
+    }
+}

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crossbeam::channel::RecvTimeoutError;
@@ -16,6 +17,7 @@ use crate::query_result_builder::{QueryBuilderConfig, QueryResultBuilder};
 use crate::stats::Stats;
 use crate::Result;
 
+use super::config::{BlockLevel, DatabaseConfigStore};
 use super::factory::DbFactory;
 use super::{
     Cond, Database, DescribeCol, DescribeParam, DescribeResponse, DescribeResult, Program, Step,
@@ -30,6 +32,7 @@ pub struct LibSqlDbFactory<W: WalHook + 'static> {
     hook: &'static WalMethodsHook<W>,
     ctx_builder: Box<dyn Fn() -> W::Context + Sync + Send + 'static>,
     stats: Stats,
+    config_store: Arc<DatabaseConfigStore>,
     extensions: Vec<PathBuf>,
     max_response_size: u64,
     /// In wal mode, closing the last database takes time, and causes other databases creation to
@@ -47,6 +50,7 @@ where
         hook: &'static WalMethodsHook<W>,
         ctx_builder: F,
         stats: Stats,
+        config_store: Arc<DatabaseConfigStore>,
         extensions: Vec<PathBuf>,
         max_response_size: u64,
     ) -> Result<Self>
@@ -58,6 +62,7 @@ where
             hook,
             ctx_builder: Box::new(ctx_builder),
             stats,
+            config_store,
             extensions,
             max_response_size,
             _db: None,
@@ -105,6 +110,7 @@ where
             self.hook,
             (self.ctx_builder)(),
             self.stats.clone(),
+            self.config_store.clone(),
             QueryBuilderConfig {
                 max_size: Some(self.max_response_size),
             },
@@ -157,6 +163,7 @@ impl LibSqlDb {
         wal_hook: &'static WalMethodsHook<W>,
         hook_ctx: W::Context,
         stats: Stats,
+        config_store: Arc<DatabaseConfigStore>,
         builder_config: QueryBuilderConfig,
     ) -> crate::Result<Self>
     where
@@ -174,6 +181,7 @@ impl LibSqlDb {
                 wal_hook,
                 &mut ctx,
                 stats,
+                config_store,
                 builder_config,
             ) {
                 Ok(conn) => {
@@ -229,6 +237,7 @@ struct Connection<'a> {
     conn: sqld_libsql_bindings::Connection<'a>,
     timed_out: bool,
     stats: Stats,
+    config_store: Arc<DatabaseConfigStore>,
     builder_config: QueryBuilderConfig,
 }
 
@@ -239,6 +248,7 @@ impl<'a> Connection<'a> {
         wal_methods: &'static WalMethodsHook<W>,
         hook_ctx: &'a mut W::Context,
         stats: Stats,
+        config_store: Arc<DatabaseConfigStore>,
         builder_config: QueryBuilderConfig,
     ) -> Result<Self> {
         let this = Self {
@@ -246,6 +256,7 @@ impl<'a> Connection<'a> {
             timeout_deadline: None,
             timed_out: false,
             stats,
+            config_store,
             builder_config,
         };
 
@@ -328,6 +339,13 @@ impl<'a> Connection<'a> {
         builder: &mut impl QueryResultBuilder,
     ) -> Result<(u64, Option<i64>)> {
         tracing::trace!("executing query: {}", query.stmt.stmt);
+
+        let max_block_level = match query.stmt.kind {
+            StmtKind::Read | StmtKind::TxnBegin | StmtKind::Other => BlockLevel::BlockReads,
+            StmtKind::Write => BlockLevel::BlockWrites,
+            StmtKind::TxnEnd => BlockLevel::BlockNothing,
+        };
+        self.config_store.check_block_level(max_block_level)?;
 
         let mut stmt = self.conn.prepare(&query.stmt.stmt)?;
 
@@ -536,6 +554,7 @@ mod test {
             conn: sqld_libsql_bindings::Connection::test(ctx),
             timed_out: false,
             stats: Stats::default(),
+            config_store: Arc::new(DatabaseConfigStore::new_test()),
             builder_config: QueryBuilderConfig::default(),
         };
 

--- a/sqld/src/database/libsql.rs
+++ b/sqld/src/database/libsql.rs
@@ -343,7 +343,7 @@ impl<'a> Connection<'a> {
         let max_block_level = match query.stmt.kind {
             StmtKind::Read | StmtKind::TxnBegin | StmtKind::Other => BlockLevel::BlockReads,
             StmtKind::Write => BlockLevel::BlockWrites,
-            StmtKind::TxnEnd => BlockLevel::BlockNothing,
+            StmtKind::TxnEnd => BlockLevel::BlockEverything,
         };
         self.config_store.check_block_level(max_block_level)?;
 

--- a/sqld/src/database/mod.rs
+++ b/sqld/src/database/mod.rs
@@ -7,6 +7,7 @@ use crate::query_analysis::{State, Statement};
 use crate::query_result_builder::{IgnoreResult, QueryResultBuilder};
 use crate::Result;
 
+pub mod config;
 pub mod dump;
 pub mod factory;
 pub mod libsql;

--- a/sqld/src/error.rs
+++ b/sqld/src/error.rs
@@ -33,6 +33,10 @@ pub enum Error {
     DbCreateTimeout,
     #[error(transparent)]
     BuilderError(#[from] QueryResultBuilderError),
+    #[error("Operation was blocked{}", .0.as_ref().map(|msg| format!(": {}", msg)).unwrap_or_default())]
+    Blocked(Option<String>),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
 }
 
 impl From<tokio::sync::oneshot::error::RecvError> for Error {

--- a/sqld/src/http/hrana_over_http_1.rs
+++ b/sqld/src/http/hrana_over_http_1.rs
@@ -137,7 +137,8 @@ fn response_error_response(err: ResponseError) -> hyper::Response<hyper::Body> {
             | StmtError::SqlNoStmt
             | StmtError::SqlManyStmts
             | StmtError::ArgsInvalid { .. }
-            | StmtError::SqlInputError { .. } => hyper::StatusCode::BAD_REQUEST,
+            | StmtError::SqlInputError { .. }
+            | StmtError::Blocked { .. } => hyper::StatusCode::BAD_REQUEST,
             StmtError::ArgsBothPositionalAndNamed => hyper::StatusCode::NOT_IMPLEMENTED,
             StmtError::TransactionTimeout | StmtError::TransactionBusy => {
                 hyper::StatusCode::SERVICE_UNAVAILABLE

--- a/sqld/src/lib.rs
+++ b/sqld/src/lib.rs
@@ -31,6 +31,7 @@ use sha256::try_digest;
 
 pub use sqld_libsql_bindings as libsql;
 
+mod admin_api;
 mod auth;
 pub mod database;
 mod error;
@@ -74,6 +75,7 @@ pub struct Config {
     pub http_auth: Option<String>,
     pub http_self_url: Option<String>,
     pub hrana_addr: Option<SocketAddr>,
+    pub admin_addr: Option<SocketAddr>,
     pub auth_jwt_key: Option<String>,
     pub backend: Backend,
     pub writer_rpc_addr: Option<String>,
@@ -110,6 +112,7 @@ impl Default for Config {
             http_auth: None,
             http_self_url: None,
             hrana_addr: None,
+            admin_addr: None,
             auth_jwt_key: None,
             backend: Backend::Libsql,
             writer_rpc_addr: None,
@@ -144,6 +147,7 @@ async fn run_service<D: Database>(
     join_set: &mut JoinSet<anyhow::Result<()>>,
     idle_shutdown_layer: Option<IdleShutdownLayer>,
     stats: Stats,
+    db_config_store: Arc<DatabaseConfigStore>,
 ) -> anyhow::Result<()> {
     let auth = get_auth(config)?;
 
@@ -194,6 +198,10 @@ async fn run_service<D: Database>(
                 .await
                 .context("Hrana listener failed")
         });
+    }
+
+    if let Some(addr) = config.admin_addr {
+        join_set.spawn(admin_api::run_admin_api(addr, db_config_store));
     }
 
     match &config.heartbeat_url {
@@ -315,7 +323,7 @@ async fn start_replica(
         channel,
         uri,
         stats.clone(),
-        db_config_store,
+        db_config_store.clone(),
         applied_frame_no_receiver,
         config.max_response_size,
     )
@@ -327,6 +335,7 @@ async fn start_replica(
         join_set,
         idle_shutdown_layer,
         stats,
+        db_config_store,
     )
     .await?;
 
@@ -473,7 +482,7 @@ async fn start_primary(
             }
         },
         stats.clone(),
-        db_config_store,
+        db_config_store.clone(),
         valid_extensions,
         config.max_response_size,
     )
@@ -494,7 +503,15 @@ async fn start_primary(
         ));
     }
 
-    run_service(db_factory, config, join_set, idle_shutdown_layer, stats).await?;
+    run_service(
+        db_factory,
+        config,
+        join_set,
+        idle_shutdown_layer,
+        stats,
+        db_config_store,
+    )
+    .await?;
 
     Ok(())
 }

--- a/sqld/src/main.rs
+++ b/sqld/src/main.rs
@@ -40,9 +40,13 @@ struct Cli {
     #[clap(long)]
     enable_http_console: bool,
 
-    /// The address and port the Hrana server listens to.
+    /// Address and port for the legacy, Web-Socket-only Hrana server.
     #[clap(long, short = 'l', env = "SQLD_HRANA_LISTEN_ADDR")]
     hrana_listen_addr: Option<SocketAddr>,
+
+    /// The address and port for the admin HTTP API.
+    #[clap(long, env = "SQLD_ADMIN_LISTEN_ADDR")]
+    admin_listen_addr: Option<SocketAddr>,
 
     /// Path to a file with a JWT decoding key used to authenticate clients in the Hrana and HTTP
     /// APIs. The key is either a PKCS#8-encoded Ed25519 public key in PEM, or just plain bytes of
@@ -239,6 +243,7 @@ fn config_from_args(args: Cli) -> Result<Config> {
         http_addr: Some(args.http_listen_addr),
         enable_http_console: args.enable_http_console,
         hrana_addr: args.hrana_listen_addr,
+        admin_addr: args.admin_listen_addr,
         auth_jwt_key,
         http_auth: args.http_auth,
         http_self_url: args.http_self_url,


### PR DESCRIPTION
- Add `DatabaseConfigStore` structure, which stores a `DatabaseConfig` in a JSON file (temporary solution, we will use JSONs in SQLite once sqld supports multitenancy).
- `DatabaseConfig` includes the `BlockLevel`, which specifies which database operations should be blocked.
- Introduce admin HTTP API, which listens on a different port than the public API, and can be used to read the configuration and update the block level.

Cc @athoscouto, who will be using this on the Turso platform.